### PR TITLE
feat(transform-hook): UseTransformComponent added

### DIFF
--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -2,3 +2,4 @@ export * from "./use-controls";
 export * from "./use-transform-init";
 export * from "./use-transform-effect";
 export * from "./use-transform-context";
+export * from "./use-transform-component";

--- a/src/hooks/use-transform-component.tsx
+++ b/src/hooks/use-transform-component.tsx
@@ -1,0 +1,16 @@
+import { useMemo } from "react";
+
+import { useTransformContext } from "./use-transform-context";
+import { getState } from "utils";
+import { ReactZoomPanPinchContextState } from "../models";
+
+export function useTransformComponent<T>(
+  callback: (state: ReactZoomPanPinchContextState) => T,
+): T {
+  const libraryContext = useTransformContext();
+
+  return useMemo(
+    () => callback(getState(libraryContext)),
+    [libraryContext, callback],
+  );
+}


### PR DESCRIPTION
Hook added to return an element, given the current state

Given that v3 introduces the dynamic where `useTransformEffect` is the only hook that has up to date state:

https://github.com/prc5/react-zoom-pan-pinch/blob/c0871e27907c1e9338c613d1e5abfc98a873da52/CHANGELOG.md?plain=1#L5-L7

I wanted to suggest a new style of hook that could return an item, given the internal context.

The reason for this is the following pattern.

Currently if I want to write a component that uses state from inside the context I need to copy that state using `useTransformEffect` to another piece of state to use it like this:
```tsx
const MyComponent: React.FC = () => {
  const [scale, setScale] = useState(0);

  useTransformEffect(({ state }) => {
    const currentScale = state.scale;

    setScale(currentScale);
  });

  return <div>My Scale is: {scale}</div>;
}
```

This works for what I am trying to do, but I have run into issues with synchronization and infinite loops when duplicating state like this.

The new hook I am proposing here should allow something like this:

```tsx
const MyComponent: React.FC = () => {
  return useTransformComponent(({ state }) => {
    const currentScale = state.scale;

     return <div>My Scale is: {currentScale}</div>;
  });
}
```

This would remove the duplicated state and ensure that the same state being rendered on the page is the state coming from the context.

I can add docs, tests, and examples, but I wanted to see what the response from y'all was like before adding any of that.