### PR TITLE
Add toggle double-click mode

### DIFF
--- a/src/core/double-click/double-click.logic.ts
+++ b/src/core/double-click/double-click.logic.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-param-reassign */
-import { ReactZoomPanPinchContext } from "../../models";
+import { LibrarySetup, ReactZoomPanPinchContext } from "../../models";
 import { animate } from "../animations/animations.utils";
 import { getMousePosition } from "../wheel/wheel.utils";
 import { handleZoomToPoint } from "../zoom/zoom.logic";
@@ -44,6 +44,17 @@ export const handleDoubleClickResetMode = (
   handleDoubleClickStop(contextInstance, event);
 };
 
+function getDoubleClickScale(
+  mode: LibrarySetup["doubleClick"]["mode"],
+  scale: number,
+) {
+  if (mode === "toggle") {
+    return scale === 1 ? 1 : -1;
+  }
+
+  return mode === "zoomOut" ? -1 : 1;
+}
+
 export function handleDoubleClick(
   contextInstance: ReactZoomPanPinchContext,
   event: MouseEvent | TouchEvent,
@@ -65,14 +76,7 @@ export function handleDoubleClick(
 
   if (!contentComponent) return console.error("No ContentComponent found");
 
-  const delta =
-    mode === "toggle"
-      ? contextInstance.transformState.scale === 1
-        ? 1
-        : -1
-      : mode === "zoomOut"
-      ? -1
-      : 1;
+  const delta = getDoubleClickScale(mode, contextInstance.transformState.scale);
 
   const newScale = handleCalculateButtonZoom(contextInstance, delta, step);
 

--- a/src/core/double-click/double-click.logic.ts
+++ b/src/core/double-click/double-click.logic.ts
@@ -65,7 +65,14 @@ export function handleDoubleClick(
 
   if (!contentComponent) return console.error("No ContentComponent found");
 
-  const delta = mode === "zoomOut" ? -1 : 1;
+  const delta =
+    mode === "toggle"
+      ? contextInstance.transformState.scale === 1
+        ? 1
+        : -1
+      : mode === "zoomOut"
+      ? -1
+      : 1;
 
   const newScale = handleCalculateButtonZoom(contextInstance, delta, step);
 

--- a/src/models/context.model.ts
+++ b/src/models/context.model.ts
@@ -3,12 +3,12 @@ import React from "react";
 import { animations } from "../core/animations/animations.constants";
 import { DeepNonNullable } from "./helpers.model";
 import {
-  zoomIn,
-  zoomToElement,
   centerView,
   resetTransform,
   setTransform,
+  zoomIn,
   zoomOut,
+  zoomToElement,
 } from "../core/handlers/handlers.logic";
 import { ZoomPanPinch } from "../core/instance.core";
 
@@ -92,7 +92,7 @@ export type ReactZoomPanPinchProps = {
   doubleClick?: {
     disabled?: boolean;
     step?: number;
-    mode?: "zoomIn" | "zoomOut" | "reset";
+    mode?: "zoomIn" | "zoomOut" | "reset" | "toggle";
     animationTime?: number;
     animationType?: keyof typeof animations;
     excluded?: string[];

--- a/src/stories/docs/props.tsx
+++ b/src/stories/docs/props.tsx
@@ -303,10 +303,10 @@ export const wrapperPropsTable: ComponentProps = {
         "The sensitivity of zooming in or out when the double click mode is set to 'zoomIn' or 'zoomOut'.",
     },
     mode: {
-      type: ["zoomIn", "zoomOut", "reset"],
+      type: ["zoomIn", "zoomOut", "reset", "toggle"],
       defaultValue: String(initialSetup.doubleClick.mode),
       description:
-        "The mode of the double click feature. Zoom in/Zoom out will change the scale with the given step settings. The reset functionality will take change transform to the initial values.",
+        "The mode of the double click feature. Zoom in/Zoom out will change the scale with the given step settings. The reset functionality will take change transform to the initial values. The toggle functionality will toggle between zooming in and out.",
     },
     animationTime: {
       type: ["number"],

--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -7,4 +7,4 @@ declare module "*.css" {
   export default content;
 }
 
-type SvgrComponent = React.StatelessComponent<React.SVGAttributes<SVGElement>>
+type SvgrComponent = React.StatelessComponent<React.SVGAttributes<SVGElement>>;


### PR DESCRIPTION
Fixes https://github.com/prc5/react-zoom-pan-pinch/issues/409

Note: `yarn format` also formats some other files, so I excluded those. A project maintainer should likely run `yarn format` on the `master` branch, or I can run it to be included in this PR on request.