### PR TITLE
fix: Mouse panning when used in shadow DOM

### DIFF
--- a/src/core/pan/panning.utils.ts
+++ b/src/core/pan/panning.utils.ts
@@ -16,7 +16,17 @@ export const isPanningStartAllowed = (
   const { isInitialized, wrapperComponent } = contextInstance;
 
   const target = event.target as HTMLElement;
-  const isWrapperChild = wrapperComponent?.contains(target);
+  const targetIsShadowDom = "shadowRoot" in target && "composedPath" in event;
+  const isWrapperChild = targetIsShadowDom
+    ? event.composedPath().some((el) => {
+        if (!(el instanceof Element)) {
+          return false;
+        }
+
+        return wrapperComponent?.contains(el);
+      })
+    : wrapperComponent?.contains(target);
+
   const isAllowed = isInitialized && target && isWrapperChild;
 
   if (!isAllowed) return false;


### PR DESCRIPTION
Related issue: #371 

This fixes an issue where mouse event panning wasn't functional when the component was used within shadow DOM.

This is due to [event retargeting](https://polymer-library.polymer-project.org/2.0/docs/devguide/shadow-dom#event-retargeting). When the `mousemove`/etc events bubble up from within the shadow DOM, the event target gets set to the shadow DOM's host element. This breaks an assumption in the panning event handler that `event.target` will be a descendent of the `wrapperComponent`, so when the library calls `wrapperComponent.contains(event.target)`, the result is always `false`.

This PR addresses the issue by checking if the event target is a shadow DOM host. If it is, we check if `wrapperComponent` contains any elements returned by `event.composedPath()`, instead of `event.target`. [`event.composedPath()`](https://developer.mozilla.org/en-US/docs/Web/API/Event/composedPath) returns an array with the full bubbling path of the event and is designed for situations like this.

Here's a diagram which, uhh, seemed like a good idea at the time:

![bubbling](https://github.com/BetterTyped/react-zoom-pan-pinch/assets/808159/80cad154-ee7a-47f7-ace0-2241513f9988)

