### PR TITLE
bugfix(TransformWrapper): update props when TransformWrapper is updated

### DIFF
--- a/src/core/instance.core.ts
+++ b/src/core/instance.core.ts
@@ -110,6 +110,7 @@ export class ZoomPanPinch {
   };
 
   update = (newProps: ReactZoomPanPinchProps) => {
+    this.props = newProps;
     handleCalculateBounds(this, this.transformState.scale);
     this.setup = createSetup(newProps);
   };


### PR DESCRIPTION
Hi, when the callbacks in react are updated, the instance on update was not picking up the new props and the instance was accessing the old cached value. 