### PR TITLE
Exclude all nested elements

### DIFF
--- a/src/utils/helpers.utils.ts
+++ b/src/utils/helpers.utils.ts
@@ -2,20 +2,9 @@ export const isExcludedNode = (
   node: HTMLElement,
   excluded: string[],
 ): boolean => {
-  const targetTagName = node.tagName.toUpperCase();
-  const isExcludedTag = excluded.find(
-    (tag) => tag.toUpperCase() === targetTagName,
+  return excluded.some((exclude) =>
+    node.matches(`${exclude}, .${exclude}, ${exclude} *, .${exclude} *`),
   );
-
-  if (isExcludedTag) return true;
-
-  const isExcludedClassName = excluded.find((className) =>
-    node.classList.contains(className),
-  );
-
-  if (isExcludedClassName) return true;
-
-  return false;
 };
 
 export const cancelTimeout = (


### PR DESCRIPTION
This PR addresses #407 by determining whether a node is directly excluded or is a descendant of an excluded node using a simple constructed CSS selector that the node is matched against.

In our project we use this component to zoom/pan a large and complex DOM that has deep nested elements, so it is quite cumbersome and intrusive to add classnames to all descendants of an excluded element.

While this simple change only addresses the issue raised, ideally though the exclusion rules should be changed to be proper selectors rather than just class or tag names, that would allow unlimited flexibility, however that would also be a breaking change.
