### PR TITLE
feat: Add check for ResizeObserver availability to prevent reference errors

### DIFF
--- a/src/components/mini-map/use-resize.hook.ts
+++ b/src/components/mini-map/use-resize.hook.ts
@@ -37,6 +37,11 @@ export const useResize = <T extends HTMLElement>(
 
   useLayoutEffect(() => {
     didUnmount.current = false;
+
+    if (!("ResizeObserver" in window)) {
+      return;
+    }
+
     if (ref) {
       resizeObserverRef.current = new ResizeObserver(
         (entries: ResizeObserverEntry[]) => {


### PR DESCRIPTION
### Summary
This PR introduces a check for the availability of `ResizeObserver` in the `window` object within our custom `useResize` hook. This change aims to prevent errors in environments where `ResizeObserver` is not defined, such as server-side rendering contexts or older browsers, and during Jest testing without specific mocks.

#### Background
While implementing the `useResize` hook for element resize observation, we encountered errors in environments lacking `ResizeObserver` support. Specifically, Jest tests failed with a `ReferenceError: ResizeObserver is not defined`, unless a mock implementation was provided:

```javascript
window.ResizeObserver = jest.fn().mockImplementation(() => ({
  disconnect: jest.fn(),
  observe: jest.fn(),
}));
```

#### reference

- https://github.com/jaredLunde/react-hook/blob/master/packages/resize-observer/src/index.tsx#L11-L15
- https://github.com/wojtekmaj/react-hooks/blob/8a22977f01b01c1f2f4ffa961fa1b197baeae983/src/useResizeObserver.ts#L19-L21
