### PR TITLE
fix centerOnInit timing issue

### DIFF
--- a/src/core/instance.core.ts
+++ b/src/core/instance.core.ts
@@ -176,10 +176,21 @@ export class ZoomPanPinch {
     if (centerOnInit) {
       this.setCenter();
       this.observer = new ResizeObserver(() => {
-        this.onInitCallbacks.forEach((callback) => callback(getContext(this)));
-        this.setCenter();
-        this.observer?.disconnect();
+        const currentWidth = contentComponent.offsetWidth;
+        const currentHeight = contentComponent.offsetHeight;
+
+        if (currentWidth > 0 || currentHeight > 0) {
+          this.onInitCallbacks.forEach((callback) => callback(getContext(this)));
+          this.setCenter();
+
+          this.observer?.disconnect();
+        }
       });
+
+      // if nothing about the contentComponent has changed after 5 seconds, disconnect the observer
+      setTimeout(() => {
+        this.observer?.disconnect();
+      }, 5000);
 
       // Start observing the target node for configured mutations
       this.observer.observe(contentComponent);


### PR DESCRIPTION
This addresses this issue: https://github.com/BetterTyped/react-zoom-pan-pinch/issues/392

It seems like, maybe depending on what html and CSS you are using in the code surrounding your image, the `contentComponent` will trigger the `ResizeObserver` multiple times before the image is actually loaded. Given that the `ResizeObserver` is coded to only run once, this leaves the image off-center in some cases.

I've set it up so that the `ResizeObserver` will wait until the `contentComponent` height or width becomes greater than 0 before triggering the `setCenter` function. The timeout ensures that the observer will eventually disconnect if a resize never happens. I wasn't sure how long to set that for but 5 seconds seemed reasonable.