### PR TITLE
feat: MiniMap preview use viewport ratio

### DIFF
--- a/src/components/mini-map/mini-map.tsx
+++ b/src/components/mini-map/mini-map.tsx
@@ -51,6 +51,21 @@ export const MiniMap: React.FC<MiniMapProps> = ({
   const wrapperRef = useRef<HTMLDivElement | null>(null);
   const previewRef = useRef<HTMLDivElement | null>(null);
 
+  const getViewportSize = useCallback(() => {
+    if (instance.wrapperComponent) {
+      const rect = instance.wrapperComponent.getBoundingClientRect();
+
+      return {
+        width: rect.width,
+        height: rect.height
+      };
+    }
+    return {
+      width: 0,
+      height: 0
+    };
+  }, [instance.wrapperComponent]);
+
   const getContentSize = useCallback(() => {
     if (instance.contentComponent) {
       const rect = instance.contentComponent.getBoundingClientRect();
@@ -116,7 +131,7 @@ export const MiniMap: React.FC<MiniMapProps> = ({
       mainRef.current.style.height = `${miniSize.height}px`;
     }
     if (previewRef.current) {
-      const size = getContentSize();
+      const size = getViewportSize();
       const scale = computeMiniMapScale();
       const previewScale = scale * (1 / instance.transformState.scale);
       const transform = instance.handleTransformStyles(


### PR DESCRIPTION
Using viewport to generate a preview, thereby making the minimap display more intuitive.

Also fixed https://github.com/BetterTyped/react-zoom-pan-pinch/issues/471

Old:

![minimap-old](https://github.com/BetterTyped/react-zoom-pan-pinch/assets/1730277/cc267dff-c05c-44c6-acfc-b1150a9d562b)

New:

![minimap](https://github.com/BetterTyped/react-zoom-pan-pinch/assets/1730277/9819c04b-94be-4341-b119-e9a2cf388ac4)
