### PR TITLE
fix: only call onDoubleClick for the dblclick event and not for the detected doubleTab in onTouchPanningStart

### DIFF
--- a/src/core/instance.core.ts
+++ b/src/core/instance.core.ts
@@ -376,9 +376,7 @@ export class ZoomPanPinch {
 
     const isDoubleTap = this.lastTouch && +new Date() - this.lastTouch < 200;
 
-    if (isDoubleTap && event.touches.length === 1) {
-      this.onDoubleClick(event);
-    } else {
+    if (!isDoubleTap) {
       this.lastTouch = +new Date();
 
       handleCancelAnimation(this);


### PR DESCRIPTION
The Pull Requests addresses the issue: #453 

The problem is that the `onDoubleClick` function is fired twice, once by the correct `dblClick` and the second time by the `touchstart` event.

`onTouchPanningStart` has its own implementation to detect if it was a double tap or not, and if it was, it fired the `onDoubleClick` function. I think the call to `onDoubleClick` is no longer needed and can be removed in favor of the `dbClick` event.

I tested the implementation on the following devices:
- iOS 17.5 Safari 
- iOS 17.5 Chrome
- Android 9 Chrome 126
- MacBook Safari