### PR TITLE
Fixes blurry images on Safari

### DIFF
--- a/src/components/transform-component/transform-component.module.css
+++ b/src/components/transform-component/transform-component.module.css
@@ -13,6 +13,7 @@
   user-select: none;
   margin: 0;
   padding: 0;
+  transform: translate3d(0, 0, 0);
 }
 .content {
   display: flex;


### PR DESCRIPTION
This fixed an issue when transforming images in Safari both on desktop and mobile.



This issue was first reported by https://github.com/BetterTyped/react-zoom-pan-pinch/issues/374. 