### PR TITLE
fix: zoom does not work when pinching on mobile

### DIFF
--- a/src/core/instance.core.ts
+++ b/src/core/instance.core.ts
@@ -391,7 +391,10 @@ export class ZoomPanPinch {
 
     if (!isAllowed) return;
 
-    const isDoubleTap = this.lastTouch && +new Date() - this.lastTouch < 200;
+    const isDoubleTap =
+      this.lastTouch &&
+      +new Date() - this.lastTouch < 200 &&
+      event.touches.length === 1;
 
     if (!isDoubleTap) {
       this.lastTouch = +new Date();


### PR DESCRIPTION
This PR addresses:  https://github.com/BetterTyped/react-zoom-pan-pinch/issues/487

I have output the log of touch events during a pinch on mobile, and it seems to be behaving as follows:

1. The touch event `event.touches.length === 2` is fired only once at the pinch start
2. Two touch events are fired at the pinch start: `event.touches.length === 1` and `event.touches.length === 2`

In case 1, the pinch works correctly. However, in case 2, the quick, consecutive tap events are interpreted as a double-tap.
 To address case 2, I have changed it so that only single-finger touches are treated as a double-tap.