### PR TITLE
Fix: Ensure TransformComponent Handles Conditional Rendering Gracefully

### DIFF
--- a/src/core/bounds/bounds.utils.ts
+++ b/src/core/bounds/bounds.utils.ts
@@ -67,7 +67,12 @@ export const calculateBounds = (
   const { centerZoomedOut } = contextInstance.setup;
 
   if (!wrapperComponent || !contentComponent) {
-    throw new Error("Components are not mounted");
+    return {
+      minPositionX: 0,
+      maxPositionX: 0,
+      minPositionY: 0,
+      maxPositionY: 0,
+    }
   }
 
   const {


### PR DESCRIPTION
This PR resolves [issue #516](https://github.com/BetterTyped/react-zoom-pan-pinch/issues/516), addressing an error where components are not mounted when `TransformComponent` is rendered conditionally or delayed.

Changes:
- Added a safeguard to handle cases where wrapperComponent or contentComponent are unavailable by returning default position values.
- This ensures compatibility and flexibility when using TransformComponent at any depth within the React tree, regardless of its conditional rendering.