### PR TITLE
Fix: Prevent Incorrect Displacement during Animation

### DIFF
--- a/src/core/instance.core.ts
+++ b/src/core/instance.core.ts
@@ -49,6 +49,7 @@ import {
 } from "./double-click/double-click.logic";
 
 type StartCoordsType = { x: number; y: number } | null;
+type ClientCoordsType = StartCoordsType;
 
 export class ZoomPanPinch {
   public props: ReactZoomPanPinchProps;
@@ -79,6 +80,7 @@ export class ZoomPanPinch {
   public isPanning = false;
   public isWheelPanning = false;
   public startCoords: StartCoordsType = null;
+  public clientCoords: ClientCoordsType = null;
   public lastTouch: number | null = null;
   // pinch helpers
   public distance: null | number = null;

--- a/src/core/pan/panning.logic.ts
+++ b/src/core/pan/panning.logic.ts
@@ -60,7 +60,7 @@ export function handlePanning(
   clientX: number,
   clientY: number,
 ): void {
-  const { startCoords, setup } = contextInstance;
+  const { startCoords, clientCoords, setup } = contextInstance;
   const { sizeX, sizeY } = setup.alignmentAnimation;
 
   if (!startCoords) return;
@@ -69,7 +69,7 @@ export function handlePanning(
   const paddingValueX = getPaddingValue(contextInstance, sizeX);
   const paddingValueY = getPaddingValue(contextInstance, sizeY);
 
-  handleCalculateVelocity(contextInstance, { x, y });
+  if(clientCoords?.x != clientX && clientCoords?.y != clientY) handleCalculateVelocity(contextInstance, { x, y });
   handleNewPosition(contextInstance, x, y, paddingValueX, paddingValueY);
 }
 

--- a/src/core/pan/panning.utils.ts
+++ b/src/core/pan/panning.utils.ts
@@ -64,6 +64,7 @@ export const handlePanningSetup = (
   const y = event.clientY;
 
   contextInstance.startCoords = { x: x - positionX, y: y - positionY };
+  contextInstance.clientCoords = {x: x, y:  y};
 };
 
 export const handleTouchPanningSetup = (
@@ -81,6 +82,7 @@ export const handleTouchPanningSetup = (
     const x = touches[0].clientX;
     const y = touches[0].clientY;
     contextInstance.startCoords = { x: x - positionX, y: y - positionY };
+    contextInstance.clientCoords = {x: x, y:  y};
   }
 };
 export function handlePanToBounds(

--- a/src/stories/docs/Introduction.stories.mdx
+++ b/src/stories/docs/Introduction.stories.mdx
@@ -43,8 +43,8 @@ import { Meta } from "@storybook/addon-docs/blocks";
 > Super fast and light react npm package for zooming, panning and pinching html
 > elements in easy way
 
-- [Demo](https://prc5.github.io/react-zoom-pan-pinch/?path=/story/examples-big-image--big-image)
-- [Docs](https://prc5.github.io/react-zoom-pan-pinch/?path=/story/docs-props--page)
+- [Demo](https://bettertyped.github.io/react-zoom-pan-pinch/?path=/story/examples-big-image--big-image)
+- [Docs](https://bettertyped.github.io/react-zoom-pan-pinch/?path=/story/docs-props--page)
 
 ## Key Features
 

--- a/src/stories/hooks/use-transform-context.stories.mdx
+++ b/src/stories/hooks/use-transform-context.stories.mdx
@@ -4,12 +4,35 @@ import { Meta } from "@storybook/addon-docs/blocks";
 
 # useTransformContext
 
+Must be used within the `TransformWrapper`.
+
 Use the direct access to the `Zoom-Pan-Pinch instance` and create your own hooks
 and logic with ease.
+
+An example is accessing the current positions and scale of the `instance` through `context.transformState`. 
 
 ### Example
 
 ```tsx
-// Simple access to the context instance
-const context = useTransformContext();
+  const App = () => {
+
+  const MyComponent = () => {
+    // Simple access to the context
+    const context = useTransformContext();
+    return (...)
+  };
+
+
+  return (
+        <TransformWrapper
+          {...props}
+        >
+            <TransformComponent>
+            <MyComponent/>
+            </TransformComponent>
+        </TransformWrapper>
+  );
+};
+
+
 ```

--- a/src/stories/hooks/use-transform-context.stories.mdx
+++ b/src/stories/hooks/use-transform-context.stories.mdx
@@ -28,7 +28,7 @@ An example is accessing the current positions and scale of the `instance` throug
           {...props}
         >
             <TransformComponent>
-            <MyComponent/>
+                <MyComponent/>
             </TransformComponent>
         </TransformWrapper>
   );


### PR DESCRIPTION
This PR fixes the issue where unintended transformation occurs when a user clicks on the image while animation is occuring. To accurately assess the issue, please see the attached video. 

This issue occurs when `velocityDisabled` is `false`

https://github.com/user-attachments/assets/ed1c7a7c-5e7f-44a3-983e-1e765926b97f

This issue occurs because `positionX` and `positionY` in `transformState` are continuously updated during the animation. As a result, startCoords ends up reflecting the current position during panning rather than the initial position at the start of the pan gesture, which generates a value in `handleCalculateVelocity` that leads to an incorrect displacement.

To address this, I added a prop to store the coordinates from when the panning starts. If the clicked coordinate does not change during panning, then velocity should not be calculated.

Changes:

- Added a class prop named `clientCoords` to store the clientX and clientY of the Event. 

- Only calculate the velocity when the clicked coordinates change, preventing unintended animations from rendering.