### PR TITLE
fix: apply initial scale on KeepScale mount

### DIFF
--- a/src/components/keep-scale/keep-scale.tsx
+++ b/src/components/keep-scale/keep-scale.tsx
@@ -11,16 +11,22 @@ export const KeepScale = React.forwardRef<
   const instance = useContext(Context);
 
   useEffect(() => {
-    return instance.onChange((ctx) => {
+    const applyScale = (scale: number) => {
       if (localRef.current) {
         const positionX = 0;
         const positionY = 0;
         localRef.current.style.transform = instance.handleTransformStyles(
           positionX,
           positionY,
-          1 / ctx.instance.transformState.scale,
+          1 / scale,
         );
       }
+    };
+
+    applyScale(instance.transformState.scale);
+
+    return instance.onChange((ctx) => {
+      applyScale(ctx.instance.transformState.scale);
     });
   }, [instance]);
 


### PR DESCRIPTION
## Summary

This PR fixes an issue where the `KeepScale` component did not apply the `initialScale` when first mounted. The scale transform was only being updated on change events, causing the element to appear unscaled initially.

## Changes

- Apply `applyScale` once on mount using `instance.transformState.scale`


## Context

Previously, the scale was only applied after a `transformState` change, which meant the element rendered with an incorrect scale until the user interacted or zoomed.

## Impact

- Ensures the correct visual scaling from the initial render

https://github.com/user-attachments/assets/3ad23d9c-0191-4dc7-8bd1-03b0f5f5c6e7

Thanks! 
