### PR TITLE
Use initial scale in double click toggle mode logic

### DIFF
--- a/src/core/double-click/double-click.logic.ts
+++ b/src/core/double-click/double-click.logic.ts
@@ -47,9 +47,10 @@ export const handleDoubleClickResetMode = (
 function getDoubleClickScale(
   mode: LibrarySetup["doubleClick"]["mode"],
   scale: number,
+  initialScale?: number,
 ) {
   if (mode === "toggle") {
-    return scale === 1 ? 1 : -1;
+    return scale === (initialScale ?? 1) ? 1 : -1;
   }
 
   return mode === "zoomOut" ? -1 : 1;
@@ -76,7 +77,7 @@ export function handleDoubleClick(
 
   if (!contentComponent) return console.error("No ContentComponent found");
 
-  const delta = getDoubleClickScale(mode, contextInstance.transformState.scale);
+  const delta = getDoubleClickScale(mode, contextInstance.transformState.scale, contextInstance.props.initialScale);
 
   const newScale = handleCalculateButtonZoom(contextInstance, delta, step);
 


### PR DESCRIPTION
# Summary

Fixes an issue where double-clicking in `toggle` mode acted like `zoomOut` when `initialScale` was set to a non-default value.

# Details

Previously, in cases where `initialScale` was not `1`, the toggle mode did not behave as expected — it only zoomed out instead of toggling between zoom states.
This change ensures that toggle mode now works correctly in the "Responsive Image" example and other similar scenarios.