### PR TITLE
Fix panning not working on additionnal window

### DIFF
--- a/src/core/pan/panning.logic.ts
+++ b/src/core/pan/panning.logic.ts
@@ -69,7 +69,8 @@ export function handlePanning(
   const paddingValueX = getPaddingValue(contextInstance, sizeX);
   const paddingValueY = getPaddingValue(contextInstance, sizeY);
 
-  if(clientCoords?.x != clientX && clientCoords?.y != clientY) handleCalculateVelocity(contextInstance, { x, y });
+  if (clientCoords?.x != clientX && clientCoords?.y != clientY)
+    handleCalculateVelocity(contextInstance, { x, y });
   handleNewPosition(contextInstance, x, y, paddingValueX, paddingValueY);
 }
 

--- a/src/core/pan/panning.utils.ts
+++ b/src/core/pan/panning.utils.ts
@@ -17,9 +17,18 @@ export const isPanningStartAllowed = (
 
   const target = event.target as HTMLElement;
   const targetIsShadowDom = "shadowRoot" in target && "composedPath" in event;
+
+  // Helper function to check if an object is an Element (cross-window compatible)
+  // Using numeric constant 1 (ELEMENT_NODE) instead of Node.ELEMENT_NODE for cross-window compatibility
+  const isElement = (el: unknown): el is Element => {
+    return (
+      el != null && typeof el === "object" && (el as Element).nodeType === 1
+    );
+  };
+
   const isWrapperChild = targetIsShadowDom
     ? event.composedPath().some((el) => {
-        if (!(el instanceof Element)) {
+        if (!isElement(el)) {
           return false;
         }
 
@@ -64,7 +73,7 @@ export const handlePanningSetup = (
   const y = event.clientY;
 
   contextInstance.startCoords = { x: x - positionX, y: y - positionY };
-  contextInstance.clientCoords = {x: x, y:  y};
+  contextInstance.clientCoords = { x, y };
 };
 
 export const handleTouchPanningSetup = (
@@ -82,7 +91,7 @@ export const handleTouchPanningSetup = (
     const x = touches[0].clientX;
     const y = touches[0].clientY;
     contextInstance.startCoords = { x: x - positionX, y: y - positionY };
-    contextInstance.clientCoords = {x: x, y:  y};
+    contextInstance.clientCoords = { x, y };
   }
 };
 export function handlePanToBounds(


### PR DESCRIPTION
## Description

This PR fixes an issue where panning functionality was not working in additional windows due to an incorrect `instanceof` check.

## Changes Made

- Updated the `instanceof` check to properly handle additional windows/instances.

## Before the Fix

Panning gestures (e.g., drag-to-move) were ignored or broken in additional windows or instances.

## After the Fix

Panning now works as expected in all windows, including secondary or embedded instances.

## How to Test

1. Open the application in multiple windows or iframes.
2. Attempt to pan (drag-to-move) in each window.
3. Verify that panning works smoothly in all instances.

